### PR TITLE
出品者に表示される購入ボタンのメッセージ変更

### DIFF
--- a/app/views/items/_item-detail.html.haml
+++ b/app/views/items/_item-detail.html.haml
@@ -65,7 +65,7 @@
           （税込）
     - if user_signed_in? && current_user.id == @item.user.id
       .item-details-wrapper__container__inner__body__purcharseBtn.item-details-wrapper__container__inner__body__purcharseBtn--disable
-        %button{:disabled => 'disabled'} 購入画面に進む
+        %button{:disabled => 'disabled'} 出品者のため購入不可
     - elsif @item.buyer_id.present?
       .item-details-wrapper__container__inner__body__purcharseBtn.item-details-wrapper__container__inner__body__purcharseBtn--disable
         %button{:disabled => 'disabled'} 売り切れ


### PR DESCRIPTION
# What
出品者に表示される購入ボタンのメッセージ変更しました。

# Why
出品者にも無効化された『購入へ進む』ボタンが表示されていて購入できるように感じさせてしまうため、ボタンに表示されるテキストを『出品者のため購入不可』に変更しました。
リンクは貼っておらず、ボタンはDisabledを適用しているためクリックしても何も起こらないようになっています。