### PR TITLE
出品画像選択ボタンの表示数を制限

### DIFF
--- a/app/assets/stylesheets/_items.scss
+++ b/app/assets/stylesheets/_items.scss
@@ -33,14 +33,15 @@
       flex-direction: column;
     }
   &--image{
-    height:112px;
     background-color:rgb(245,245,245);
     border: 1px dotted black;
     font-size: 20px;
     position: relative;
     text-align: center;
     margin-bottom: 20px;
-    // overflow: scroll;
+    div:nth-child(n+6) {
+      display:none;
+    }
   }
   &--shipping_image{
     margin-bottom:20px;


### PR DESCRIPTION
# What
出品画像に選択できる画像の数を５つに制限しました。

# Why
- 出品ページで複数の画像を選択すると編集を行うのにスクロール操作が必要だったため`overflow: scroll;`を無効にして内包する要素に合わせブロックが伸縮するようにしました。
- 商品詳細ページ表示する画像の数は５つを想定しているため。