### PR TITLE
商品画像編集ブロックの高さ制限を無くしました

### DIFF
--- a/app/assets/stylesheets/_items.scss
+++ b/app/assets/stylesheets/_items.scss
@@ -39,9 +39,6 @@
     position: relative;
     text-align: center;
     margin-bottom: 20px;
-    div:nth-child(n+6) {
-      display:none;
-    }
   }
   &--shipping_image{
     margin-bottom:20px;


### PR DESCRIPTION
# What
商品画像編集ブロックの高さ制限を無くしました。

# Why
商品編集ページで画像の追加ボタンが隠れてしまうため